### PR TITLE
Update session_ext.hxx to include variant

### DIFF
--- a/include/zenoh/api/ext/session_ext.hxx
+++ b/include/zenoh/api/ext/session_ext.hxx
@@ -16,6 +16,7 @@
 
 #include <algorithm>
 #include <optional>
+#include <variant>
 
 #include "../base.hxx"
 #include "../enums.hxx"


### PR DESCRIPTION
GCC  requires `variant` to be explicitly included